### PR TITLE
fix: include fieldless variants in is_x, allow creating fieldless variants

### DIFF
--- a/tests/wrapper_tests.rs
+++ b/tests/wrapper_tests.rs
@@ -7,6 +7,12 @@ pub mod rust {
         Two,
     }
 
+    #[derive(Clone)]
+    pub enum TestUnionEnum {
+        Unit,
+        String(String),
+    }
+
     #[derive(Clone, Copy)]
     pub struct TestStruct {
         pub test_enum_unaliased: TestEnum,
@@ -18,10 +24,17 @@ pub mod python {
     use super::rust::*;
 
     use pyo3::pymethods;
-    use rigetti_pyo3::{create_init_submodule, py_wrap_data_struct, py_wrap_simple_enum};
+    use rigetti_pyo3::{create_init_submodule, py_wrap_data_struct, py_wrap_simple_enum, py_wrap_union_enum};
 
     create_init_submodule! {
-        classes: [ PyTestEnumUnaliased, PyTestEnumAliased, PyTestStruct ],
+        classes: [ PyTestEnumUnaliased, PyTestEnumAliased, PyTestStruct, PyTestUnionEnum ],
+    }
+
+    py_wrap_union_enum! {
+        PyTestUnionEnum(TestUnionEnum) as "TestUnionEnum" {
+            unit: Unit,
+            string: String => String
+        }
     }
 
     py_wrap_simple_enum! {
@@ -68,7 +81,7 @@ fn test_enum_as_data_struct_member() {
     pyo3::prepare_freethreaded_python();
     let result: PyResult<()> = Python::with_gil(|py| {
         let code = r#"
-from wrapper_tests import TestEnumUnaliased, TestEnumAliased, TestStruct
+from wrapper_tests import TestEnumUnaliased, TestEnumAliased, TestStruct, TestUnionEnum
 
 struct = TestStruct()
 
@@ -80,6 +93,8 @@ struct.test_enum_aliased = TestEnumAliased.Two
 
 assert struct.test_enum_unaliased == TestEnumUnaliased.Two
 assert struct.test_enum_aliased == TestEnumAliased.Two
+
+assert TestUnionEnum.new_unit().is_unit()
 "#;
         PyModule::from_code(py, code, "example.py", "example")?;
 


### PR DESCRIPTION
Resolves #15.

This modifies the `py_wrap_union_enum` macro in two ways:

1. `is_x` now works correctly for fieldless variants.
2. Unitless variants get a `new_x` method generated for them as a counterpart to `from_x`. This was added in part because it was missing and in part to be able to test (1).

Any `pyi` files in dependent projects using union enums with fieldless variants will need to be updated to include the `new_x` methods.