### PR TITLE
fix: Correct module naming and registration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,10 +228,10 @@ macro_rules! create_init_submodule {
             $(
                 let modules = _py.import("sys")?.getattr("modules")?;
                 $(
-                let new_name = format!("{}.{}", _name, $mod_name);
                 let submod = $crate::pyo3::types::PyModule::new(_py, &$mod_name)?;
-                $init_submod(&new_name, _py, submod)?;
-                modules.set_item(new_name, submod)?;
+                let qualified_name = format!("{}.{}", _name, $mod_name);
+                $init_submod(&qualified_name, _py, submod)?;
+                modules.set_item(qualified_name, submod)?;
                 m.add_submodule(submod)?;
                 )+
             )?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ macro_rules! create_init_submodule {
                 let modules = _py.import("sys")?.getattr("modules")?;
                 $(
                 let new_name = format!("{}.{}", _name, $mod_name);
-                let submod = $crate::pyo3::types::PyModule::new(_py, &new_name)?;
+                let submod = $crate::pyo3::types::PyModule::new(_py, &$mod_name)?;
                 $init_submod(&new_name, _py, submod)?;
                 modules.set_item(new_name, submod)?;
                 m.add_submodule(submod)?;


### PR DESCRIPTION
Closes #21 

As a workaround to [pyo3#759](https://github.com/PyO3/pyo3/issues/759), `create_init_submodule!` updates `sys.modules` to register a module. `sys.modules` is a mapping of the fully qualified path to a module, to the module object itself. `create_init_submodule!` was using the fully qualified path as both the key _and_ the name of the module. This made submodule import paths awkward to work with, especially with tooling, and in some cases it even breaks imports.

For example, [quil-py](https://github.com/rigetti/quil-rs/tree/1455-python-support-for-program-and-beyond) defines a module `quil`, with submodules `expression`, `instructions`, `program`, and `validation`.

Using the current release of `rigetti-pyo3`, notice the repetition of `quil.expression` when inspecting the `quil` module. This repetition also breaks the `import quil.expression` syntax, because the real path is `quil.quil.expression` _but_ that module is impossible to access with the usual import syntax, since `quil.quil.expression` is recognized as three modules delimited by a `.` by Python, but really it's just two modules, "quil" and "quil.expression".

![before-fix](https://user-images.githubusercontent.com/4324359/232088619-00427557-ee49-47c4-afae-7c6a80562de3.png)

After this fix, the `quil` module works as expected and we can import `quil.expression` successfully. 

![after-fix](https://user-images.githubusercontent.com/4324359/232089480-fa519b2b-fa7d-43be-bb9f-94cb48453a6a.png)
