### PR TITLE
feat: add blanket implementations of ToPython and PyTryFrom for tuples of types that implement those traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@
     semicolon_in_expressions_from_macros,
     trivial_casts,
     trivial_numeric_casts,
-    unaligned_references,
     unconditional_recursion,
     unreachable_pub,
     unsafe_code,

--- a/src/py_try_from.rs
+++ b/src/py_try_from.rs
@@ -74,6 +74,28 @@ where
     }
 }
 
+/// Provides a generic implementation of [`PyTryFrom`] for heterogenous tuples of types that themselves implement [`PyTryFrom`]
+macro_rules! impl_py_try_from_tuple {
+    ($($idx:tt $t:tt $p:tt),+) => {
+        impl<$($t,)+ $($p,)+> PyTryFrom<($($p,)+)> for ($($t,)+)
+        where
+            $($t: PyTryFrom<$p>,)+
+        {
+            fn py_try_from(py: Python, item: &($($p,)+)) -> PyResult<Self> {
+                Ok(($(
+                    $t :: py_try_from(py, &item.$idx)?,
+                )+))
+            }
+        }
+    };
+}
+
+impl_py_try_from_tuple!(0 T0 P0);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4);
+
 /// Provides a body for `py_try_from`, delegating to the implementation for the given Python type.
 ///
 /// This should be used in other macros and for generic/container types that can't be implemented

--- a/src/py_try_from.rs
+++ b/src/py_try_from.rs
@@ -95,6 +95,13 @@ impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1);
 impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2);
 impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3);
 impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8, 9 T9 P9);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8, 9 T9 P9, 10 T10 P10);
+impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8, 9 T9 P9, 10 T10 P10, 11 T11 P11);
 
 /// Provides a body for `py_try_from`, delegating to the implementation for the given Python type.
 ///

--- a/src/py_try_from.rs
+++ b/src/py_try_from.rs
@@ -90,6 +90,8 @@ macro_rules! impl_py_try_from_tuple {
     };
 }
 
+// Implement [`PyTryFrom`] for tuples of length 1 to 12, 12 being the maximum arity that [`pyo3::ToPyObject`]
+// is implemented for.
 impl_py_try_from_tuple!(0 T0 P0);
 impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1);
 impl_py_try_from_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2);

--- a/src/to_python.rs
+++ b/src/to_python.rs
@@ -95,6 +95,13 @@ impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1);
 impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2);
 impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3);
 impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8, 9 T9 P9);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8, 9 T9 P9, 10 T10 P10);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4, 5 T5 P5, 6 T6 P6, 7 T7 P7, 8 T8 P8, 9 T9 P9, 10 T10 P10, 11 T11 P11);
 
 /// Implement [`ToPython`] once for the given Rust type. Will implement for a reference to the type
 /// if a lifetime is provided.

--- a/src/to_python.rs
+++ b/src/to_python.rs
@@ -90,6 +90,8 @@ macro_rules! impl_to_python_for_tuple {
     };
 }
 
+// Implement [`ToPython`] for tuples of length 1 to 12, 12 being the maximum arity that [`pyo3::ToPyObject`]
+// is implemented for.
 impl_to_python_for_tuple!(0 T0 P0);
 impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1);
 impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2);

--- a/src/to_python.rs
+++ b/src/to_python.rs
@@ -72,6 +72,30 @@ where
     }
 }
 
+/// Provides a generic implementation of [`ToPython`] for heterogenous tuples of types that themselves implement
+/// [`ToPython`].
+macro_rules! impl_to_python_for_tuple {
+    ($($idx:tt $t:tt $p:tt),+) => {
+        impl<$($t,)+ $($p,)+> ToPython<($($p,)+)> for ($($t,)+)
+        where
+            $($t: ToPython<$p>, $p: ToPyObject,)+
+
+        {
+            fn to_python(&self, py: Python) -> PyResult<($($p,)+)> {
+                Ok(($(
+                    $t :: to_python(&self.$idx, py)?,
+                )+))
+            }
+        }
+    };
+}
+
+impl_to_python_for_tuple!(0 T0 P0);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3);
+impl_to_python_for_tuple!(0 T0 P0, 1 T1 P1, 2 T2 P2, 3 T3 P3, 4 T4 P4);
+
 /// Implement [`ToPython`] once for the given Rust type. Will implement for a reference to the type
 /// if a lifetime is provided.
 #[macro_export]


### PR DESCRIPTION
closes #22 