### PR TITLE
feat!: Update and set upper bound for the `time` dependency, increase MSRV to 1.67.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pyo3 = { version = "0.17", default-features = false, features = ["macros", "mult
 # time has a "stable minus two MSRV" policy, which doesn't jive with
 # our more permissive MSRV
 # https://github.com/time-rs/time/discussions/535
-time = { version = "<=0.3.28", optional = true }
+time = { version = ">=0.3, <=0.3.28", optional = true }
 
 [dev-dependencies]
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 categories = ["development-tools::ffi"]
 keywords = ["python", "pyo3", "ffi"]
 description = "Utilities for creating a Python wrapper for a Rust library."
-rust-version = "1.62.1"
+rust-version = "1.67.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ num-complex = { version = "0.4.0", optional = true }
 num-traits = { version = "0.2.15", optional = true }
 paste = "1.0"
 pyo3 = { version = "0.17", default-features = false, features = ["macros", "multiple-pymethods"] }
-time = { version = "0.3", optional = true }
+# time has a "stable minus two MSRV" policy, which doesn't jive with
+# our more permissive MSRV
+# https://github.com/time-rs/time/discussions/535
+time = { version = "<=0.3.17", optional = true }
 
 [dev-dependencies]
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pyo3 = { version = "0.17", default-features = false, features = ["macros", "mult
 # time has a "stable minus two MSRV" policy, which doesn't jive with
 # our more permissive MSRV
 # https://github.com/time-rs/time/discussions/535
-time = { version = "<=0.3.17", optional = true }
+time = { version = "<=0.3.28", optional = true }
 
 [dev-dependencies]
 thiserror = "1.0"

--- a/src/py_try_from.rs
+++ b/src/py_try_from.rs
@@ -427,7 +427,7 @@ where
 {
     fn py_try_from(py: Python, item: &PyDict) -> PyResult<Self> {
         let mut map = Self::with_capacity_and_hasher(item.len(), Hasher::default());
-        for (key, val) in item.iter() {
+        for (key, val) in item {
             let key = K::py_try_from(py, key)?;
             let val = V::py_try_from(py, val)?;
             map.insert(key, val);
@@ -481,7 +481,7 @@ where
 {
     fn py_try_from(py: Python, item: &PyDict) -> PyResult<Self> {
         let mut map = Self::new();
-        for (key, val) in item.iter() {
+        for (key, val) in item {
             let key = K::py_try_from(py, key)?;
             let val = V::py_try_from(py, val)?;
             map.insert(key, val);
@@ -530,7 +530,7 @@ where
 {
     fn py_try_from(py: Python, set: &PyFrozenSet) -> PyResult<Self> {
         let mut map = Self::with_capacity_and_hasher(set.len(), Hasher::default());
-        for item in set.iter() {
+        for item in set {
             let item = T::py_try_from(py, item)?;
             map.insert(item);
         }
@@ -553,7 +553,7 @@ where
 {
     fn py_try_from(py: Python, set: &PyFrozenSet) -> PyResult<Self> {
         let mut map = Self::new();
-        for item in set.iter() {
+        for item in set {
             let item = T::py_try_from(py, item)?;
             map.insert(item);
         }
@@ -618,7 +618,7 @@ where
     fn py_try_from(py: Python, py_list: &PyList) -> PyResult<Self> {
         let mut list = Self::with_capacity(py_list.len());
 
-        for item in py_list.iter() {
+        for item in py_list {
             let item = T::py_try_from(py, item)?;
             list.push(item);
         }
@@ -708,7 +708,7 @@ where
 {
     fn py_try_from(py: Python, set: &PySet) -> PyResult<Self> {
         let mut map = Self::with_capacity_and_hasher(set.len(), Hasher::default());
-        for item in set.iter() {
+        for item in set {
             let item = T::py_try_from(py, item)?;
             map.insert(item);
         }
@@ -751,7 +751,7 @@ where
 {
     fn py_try_from(py: Python, set: &PySet) -> PyResult<Self> {
         let mut map = Self::new();
-        for item in set.iter() {
+        for item in set {
             let item = T::py_try_from(py, item)?;
             map.insert(item);
         }

--- a/src/to_python.rs
+++ b/src/to_python.rs
@@ -772,7 +772,7 @@ where
     fn to_python(&self, py: Python) -> PyResult<Py<PySet>> {
         // Using PySet::new seems to do extra cloning, so build manually.
         let set = PySet::empty(py)?;
-        for item in self.iter() {
+        for item in *self {
             set.add(item.to_python(py)?)?;
         }
         Ok(set.into_py(py))
@@ -836,7 +836,7 @@ where
     fn to_python(&self, py: Python) -> PyResult<Py<PySet>> {
         // Using PySet::new seems to do extra cloning, so build manually.
         let set = PySet::empty(py)?;
-        for item in self.iter() {
+        for item in *self {
             set.add(item.to_python(py)?)?;
         }
         Ok(set.into_py(py))


### PR DESCRIPTION
The `time` crate has a [policy](https://github.com/time-rs/time/discussions/535) which means every few months the MSRV is changed. This broke our own MSRV test. I opted to restrict the `time` crate version such that it satisfies our MSRV. We could alternatively increase the MSRV to align with the `time` crate. If we go that route, we will have to keep changing our MSRV whenever `crate` changes theirs.