### PR TITLE
feat!: Update pyo3 to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ extension-module = ["pyo3/extension-module"]
 num-complex = { version = "0.4.0", optional = true }
 num-traits = { version = "0.2.15", optional = true }
 paste = "1.0"
-pyo3 = { version = "0.19", default-features = false, features = ["macros", "multiple-pymethods"] }
+pyo3 = { version = "0.20", default-features = false, features = ["macros", "multiple-pymethods"] }
 # time has a "stable minus two MSRV" policy, which doesn't jive with
 # our more permissive MSRV
 # https://github.com/time-rs/time/discussions/535

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -364,14 +364,14 @@ macro_rules! py_wrap_simple_enum {
 ///         // Used to implement `TryFrom<P> for PyFoo`. Any errors returned must be `PyErr`.
 ///         py -> rs {
 ///             py_dict: Py<PyDict> => Foo {
-///                 let bar = py_dict.as_ref(py).get_item("bar").unwrap().extract().unwrap();
-///                 let baz = py_dict.as_ref(py).get_item("baz").unwrap().extract().unwrap();
+///                 let bar = py_dict.as_ref(py).get_item("bar")?.unwrap().extract().unwrap();
+///                 let baz = py_dict.as_ref(py).get_item("baz")?.unwrap().extract().unwrap();
 ///                 Ok::<_, PyErr>(Foo { bar, baz })
 ///             },
 ///             py_tuple: Py<PyTuple> => (String, f32) {
 ///                 Ok::<_, PyErr>((
-///                     py_tuple.as_ref(py).get_item(0).unwrap().extract().unwrap(),
-///                     py_tuple.as_ref(py).get_item(1).unwrap().extract().unwrap(),
+///                     py_tuple.as_ref(py).get_item(0)?.extract().unwrap(),
+///                     py_tuple.as_ref(py).get_item(1)?.extract().unwrap(),
 ///                 ))
 ///             }
 ///         },


### PR DESCRIPTION
closes #32 

~Turns out `pyo3-asyncio` doesn't support 0.20.0 yet, which is pretty critical for some packages downstream of this. Holding off on merging in case we need to patch something for 0.19.0 users.~ `pyo3-asyncio` is updated to 0.20.0 now.