### PR TITLE
explicitly add license type to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rigetti-pyo3"
 version = "0.3.2"
 edition = "2021"
+license = "apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/rigetti/rigetti-pyo3"
 readme = "README.md"


### PR DESCRIPTION
Crates.io apparently considers this crate to have a "nonstandard" license, even though the License text is Apache-2.0. I expect this should fix that.