### PR TITLE
chore: remove license-file, capitalize license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 name = "rigetti-pyo3"
 version = "0.3.3-rc.0"
 edition = "2021"
-license = "apache-2.0"
-license-file = "LICENSE"
+license = "Apache-2.0"
 repository = "https://github.com/rigetti/rigetti-pyo3"
 readme = "README.md"
 categories = ["development-tools::ffi"]


### PR DESCRIPTION
Follow-up of https://github.com/rigetti/rigetti-pyo3/pull/39

Removes `license-file` which is redundant when `license` is specified, and capilatlizes `apache-2.0` to `Apache-2.0`