### PR TITLE
fix!: fully move all dependencies on pyo3 time types under our time feature + expose new abi3 feature for documentation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,10 +26,10 @@ jobs:
             toolchain: stable
             components: clippy
             override: true
-      - uses: actions-rs/clippy-check@v1
+      - uses: taiki-e/install-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+            tool: cargo-hack,cargo-make
+      - run: cargo make clippy
   deadlinks:
     name: Cargo Deadlinks
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
             override: true
       - uses: taiki-e/install-action@v1
         with:
-            tool: cargo-hack,cargo-make
+            tool: cargo-hack@0.6.28,cargo-make
       - run: cargo make check
   clippy:
     name: Clippy Lints
@@ -28,7 +28,7 @@ jobs:
             override: true
       - uses: taiki-e/install-action@v1
         with:
-            tool: cargo-hack,cargo-make
+            tool: cargo-hack@0.6.28,cargo-make
       - run: cargo make clippy
   deadlinks:
     name: Cargo Deadlinks
@@ -84,5 +84,5 @@ jobs:
             override: true
       - uses: taiki-e/install-action@v1
         with:
-            tool: cargo-hack,cargo-make
+            tool: cargo-hack@0.6.28,cargo-make
       - run: cargo make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ rust-version = "1.67.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["complex", "time"]
-complex = ["num-complex", "num-traits", "pyo3/num-complex"]
+time = ["dep:time"]
+abi3 = ["pyo3/abi3"]
+complex = ["dep:num-complex", "dep:num-traits", "pyo3/num-complex"]
 indexmap = ["dep:indexmap", "pyo3/indexmap"]
 extension-module = ["pyo3/extension-module"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,7 +12,7 @@
     install_crate = { rustup_component_name = "llvm-tools-preview" }
 
 [tasks.install-cargo-hack]
-    install_crate = { crate_name = "cargo-hack", binary = "cargo-hack", test_arg = ["hack", "--help"] }
+    install_crate = { crate_name = "cargo-hack", min_version = "0.6.28", binary = "cargo-hack", test_arg = ["hack", "--help"] }
 
 [tasks.check]
     clear = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,5 @@
 [env]
-    CARGO_HACK_COMMON_FLAGS = "--feature-powerset --optional-deps --exclude-features extension-module"
+    CARGO_HACK_COMMON_FLAGS = "--feature-powerset --exclude-features extension-module --mutually-exclusive-features abi3,time"
 
 [tasks.clean]
     clear = true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ That is, given Rust library crate `foo`, these macros can be used inside a crate
 
 See [the docs](https://docs.rs/rigetti-pyo3) for more.
 
+## A note on feature compatibility
+
+If you want to use [PyO3's `abi3` feature](https://pyo3.rs/v0.21.2/features#abi3), you must *disable* this library's `time` feature (which is enabled by default).  This library provides an `abi3` feature you can enable in order to explicitly request `pyo3/abi3`, which will give a clearer error message in that case.
+
 ----
 
 Rigetti PyO3 is licensed under the [Apache License 2.0](LICENSE).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,12 @@ pub use py_try_from::PyTryFrom;
 pub use pyo3;
 pub use to_python::ToPython;
 
+#[cfg(all(feature = "abi3", feature = "time"))]
+compile_error!(
+    "Cannot enable the time feature with the pyo3/abi3 feature, \
+     but you've asked for rigetti-pyo3 to be abi3-compatible."
+);
+
 /// Implemented by error types generated with [`py_wrap_error`].
 ///
 /// Trait-ifies the ability to convert an error into a [`PyErr`](pyo3::PyErr).

--- a/src/to_python/mod.rs
+++ b/src/to_python/mod.rs
@@ -18,13 +18,17 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::BuildHasher;
 
 use pyo3::conversion::IntoPy;
+
 use pyo3::types::{
     PyBool, PyByteArray, PyBytes, PyDict, PyFloat, PyFrozenSet, PyList, PyLong, PySet, PyString,
 };
+
+#[cfg(feature = "time")]
 use pyo3::{
     exceptions::PyValueError,
     types::{PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo},
 };
+
 use pyo3::{Py, PyAny, PyResult, Python, ToPyObject};
 
 #[cfg(feature = "complex")]
@@ -202,6 +206,7 @@ private_impl_to_python_with_reference!(&self, py, Vec<u8> => Py<PyBytes> {
 
 // ==== Date ====
 
+#[cfg(feature = "time")]
 impl_for_self!(Py<PyDate>);
 
 #[cfg(feature = "time")]
@@ -217,6 +222,7 @@ private_impl_to_python_pyany!(Date => Py<PyDate>);
 
 // ==== DateTime ====
 
+#[cfg(feature = "time")]
 impl_for_self!(Py<PyDateTime>);
 
 #[cfg(feature = "time")]
@@ -269,6 +275,7 @@ private_impl_to_python_pyany!(OffsetDateTime => Py<PyDateTime>);
 
 // ==== Delta ====
 
+#[cfg(feature = "time")]
 impl_for_self!(Py<PyDelta>);
 
 #[cfg(feature = "time")]
@@ -288,6 +295,7 @@ private_impl_to_python_with_reference!(&self, py, Duration => Py<PyDelta> {
 #[cfg(feature = "time")]
 private_impl_to_python_pyany!(Duration => Py<PyDelta>);
 
+#[cfg(feature = "time")]
 private_impl_to_python_with_reference!(&self, py, std::time::Duration => Py<PyDelta> {
     /// The number of seconds in a day.
     const DAY_FACTOR: u64 = 60 * 60 * 24;
@@ -310,6 +318,7 @@ private_impl_to_python_with_reference!(&self, py, std::time::Duration => Py<PyDe
     PyDelta::new(py, days, seconds, microseconds, true).map(|delta| delta.into_py(py))
 });
 
+#[cfg(feature = "time")]
 private_impl_to_python_pyany!(std::time::Duration => Py<PyDelta>);
 
 // ==== Dict ====
@@ -846,6 +855,7 @@ private_impl_to_python_with_reference!(&self, py, String => Py<PyString> {
 
 // ==== Time ====
 
+#[cfg(feature = "time")]
 impl_for_self!(Py<PyTime>);
 
 #[cfg(feature = "time")]
@@ -867,6 +877,7 @@ private_impl_to_python_pyany!((Time, Option<UtcOffset>) => Py<PyTime>);
 
 // ==== TzInfo ====
 
+#[cfg(feature = "time")]
 impl_for_self!(Py<PyTzInfo>);
 
 #[cfg(feature = "time")]


### PR DESCRIPTION
I somehow missed `to_python` last time, despite the fact that I thought I'd tried building it.