### PR TITLE
feat: update to PyO3 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ extension-module = ["pyo3/extension-module"]
 num-complex = { version = "0.4.0", optional = true }
 num-traits = { version = "0.2.15", optional = true }
 paste = "1.0"
-pyo3 = { version = "0.20", default-features = false, features = ["macros", "multiple-pymethods"] }
+pyo3 = { version = "0.21", default-features = false, features = ["macros", "multiple-pymethods"] }
 # time has a "stable minus two MSRV" policy, which doesn't jive with
 # our more permissive MSRV
 # https://github.com/time-rs/time/discussions/535


### PR DESCRIPTION
It seems that `pyo3-asyncio` is no longer maintained. We should consider forking it ourselves rather than relying on the `pyo3-asyncio-0-21` fork.

Discussion here: https://rigetti.slack.com/archives/G011GB25W0K/p1728432620213279