### PR TITLE
fix: update non-pyo3 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ pyo3 = { version = "0.20", default-features = false, features = ["macros", "mult
 # time has a "stable minus two MSRV" policy, which doesn't jive with
 # our more permissive MSRV
 # https://github.com/time-rs/time/discussions/535
-time = { version = ">=0.3, <=0.3.36", optional = true }
+time = { version = ">=0.3, <=0.3.37", optional = true }
 indexmap = { version = "2.0.0", optional = true }
 
 [dev-dependencies]
-thiserror = "1.0"
+thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 categories = ["development-tools::ffi"]
 keywords = ["python", "pyo3", "ffi"]
 description = "Utilities for creating a Python wrapper for a Rust library."
-rust-version = "1.67.0"
+rust-version = "1.67.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/deny.toml
+++ b/deny.toml
@@ -1,20 +1,21 @@
+[graph]
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = true
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+feature-depth = 1
+
 [advisories]
-db-path = "~/.cargo/advisory-db"
 db-urls = [ "https://github.com/rustsec/advisory-db",]
-vulnerability = "deny"
-unmaintained = "deny"
-yanked = "deny"
-notice = "deny"
 ignore = []
 
 [licenses]
 unused-allowed-license = "allow"
-unlicensed = "deny"
-allow = [ "Apache-2.0", "ISC", "MIT", "OpenSSL", "BSD-3-Clause", "BSL-1.0", "Apache-2.0 WITH LLVM-exception", "Unicode-DFS-2016",]
-deny = []
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
+allow = [ "Apache-2.0", "ISC", "MIT", "OpenSSL", "BSD-3-Clause", "BSL-1.0", "Apache-2.0 WITH LLVM-exception",
+"Unicode-DFS-2016", "Unicode-3.0"]
 confidence-threshold = 0.8
 [[licenses.exceptions]]
 allow = [ "MPL-2.0",]
@@ -28,8 +29,6 @@ expression = "MIT AND ISC AND OpenSSL"
 [[licenses.clarify.license-files]]
 path = "LICENSE"
 hash = 3171872035
-
-
 [[licenses.clarify]]
 name = "encoding_rs"
 version = "*"
@@ -38,17 +37,82 @@ expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
 path = "COPYRIGHT"
 hash = 972598577
 
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = true
+registries = []
 
 [bans]
+# Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
 wildcards = "deny"
 highlight = "all"
-skip-tree = []
+workspace-default-features = "allow"
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# List of crates to deny
+deny = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
 
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = [ "https://github.com/rust-lang/crates.io-index",]
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
 
 [sources.allow-org]
-github = [ "rigetti",]
+# github.com organizations to allow git sources for
+github = ["rigetti"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    pointer_structural_match,
     semicolon_in_expressions_from_macros,
     trivial_casts,
     trivial_numeric_casts,

--- a/src/to_python/complex.rs
+++ b/src/to_python/complex.rs
@@ -24,7 +24,7 @@ use crate::{impl_for_self, ToPython};
 impl_for_self!(Py<PyComplex>);
 
 #[cfg(feature = "complex")]
-impl<'a, F> ToPython<Py<PyComplex>> for &'a Complex<F>
+impl<F> ToPython<Py<PyComplex>> for &Complex<F>
 where
     F: Copy + Float + FloatConst + Into<c_double>,
 {
@@ -44,7 +44,7 @@ where
 }
 
 #[cfg(feature = "complex")]
-impl<'a, F> ToPython<Py<PyAny>> for &'a Complex<F>
+impl<F> ToPython<Py<PyAny>> for &Complex<F>
 where
     F: Copy + Float + FloatConst + Into<c_double>,
 {

--- a/src/to_python/indexmap.rs
+++ b/src/to_python/indexmap.rs
@@ -17,7 +17,7 @@ use pyo3::{types::PyDict, IntoPy, Py, PyAny, PyResult, Python, ToPyObject};
 
 use crate::ToPython;
 
-impl<'a, K1, K2, V1, V2, S> ToPython<IndexMap<K2, V2>> for &'a IndexMap<K1, V1, S>
+impl<K1, K2, V1, V2, S> ToPython<IndexMap<K2, V2>> for &IndexMap<K1, V1, S>
 where
     K1: ToPython<K2>,
     V1: ToPython<V2>,
@@ -35,7 +35,7 @@ where
     }
 }
 
-impl<'a, K, V, S> ToPython<Py<PyDict>> for &'a IndexMap<K, V, S>
+impl<K, V, S> ToPython<Py<PyDict>> for &IndexMap<K, V, S>
 where
     K: ToPython<Py<PyAny>> + std::fmt::Debug,
     V: ToPython<Py<PyAny>>,
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<'a, K, V, S> ToPython<Py<PyAny>> for &'a IndexMap<K, V, S>
+impl<K, V, S> ToPython<Py<PyAny>> for &IndexMap<K, V, S>
 where
     K: ToPython<Py<PyAny>> + std::fmt::Debug,
     V: ToPython<Py<PyAny>>,

--- a/src/to_python/mod.rs
+++ b/src/to_python/mod.rs
@@ -56,7 +56,7 @@ pub trait ToPython<P: ToPyObject> {
     fn to_python(&self, py: Python) -> PyResult<P>;
 }
 
-impl<'a, T, P> ToPython<P> for &'a Box<T>
+impl<T, P> ToPython<P> for &Box<T>
 where
     T: ToPython<P>,
     P: ToPyObject,
@@ -325,7 +325,7 @@ private_impl_to_python_pyany!(std::time::Duration => Py<PyDelta>);
 
 impl_for_self!(Py<PyDict>);
 
-impl<'a, K1, K2, V1, V2, Hasher> ToPython<HashMap<K2, V2>> for &'a HashMap<K1, V1, Hasher>
+impl<K1, K2, V1, V2, Hasher> ToPython<HashMap<K2, V2>> for &HashMap<K1, V1, Hasher>
 where
     K1: ToPython<K2>,
     V1: ToPython<V2>,
@@ -343,7 +343,7 @@ where
     }
 }
 
-impl<'a, K, V, Hasher> ToPython<Py<PyDict>> for &'a HashMap<K, V, Hasher>
+impl<K, V, Hasher> ToPython<Py<PyDict>> for &HashMap<K, V, Hasher>
 where
     K: ToPython<Py<PyAny>> + std::fmt::Debug,
     V: ToPython<Py<PyAny>>,
@@ -359,7 +359,7 @@ where
     }
 }
 
-impl<'a, K, V, Hasher> ToPython<Py<PyAny>> for &'a HashMap<K, V, Hasher>
+impl<K, V, Hasher> ToPython<Py<PyAny>> for &HashMap<K, V, Hasher>
 where
     K: ToPython<Py<PyAny>> + std::fmt::Debug,
     V: ToPython<Py<PyAny>>,
@@ -401,7 +401,7 @@ where
     }
 }
 
-impl<'a, K1, K2, V1, V2> ToPython<BTreeMap<K2, V2>> for &'a BTreeMap<K1, V1>
+impl<K1, K2, V1, V2> ToPython<BTreeMap<K2, V2>> for &BTreeMap<K1, V1>
 where
     K1: ToPython<K2> + std::fmt::Debug,
     V1: ToPython<V2>,
@@ -419,7 +419,7 @@ where
     }
 }
 
-impl<'a, K, V> ToPython<Py<PyDict>> for &'a BTreeMap<K, V>
+impl<K, V> ToPython<Py<PyDict>> for &BTreeMap<K, V>
 where
     K: ToPython<Py<PyAny>> + std::fmt::Debug,
     V: ToPython<Py<PyAny>>,
@@ -435,7 +435,7 @@ where
     }
 }
 
-impl<'a, K, V> ToPython<Py<PyAny>> for &'a BTreeMap<K, V>
+impl<K, V> ToPython<Py<PyAny>> for &BTreeMap<K, V>
 where
     K: ToPython<Py<PyAny>> + std::fmt::Debug,
     V: ToPython<Py<PyAny>>,
@@ -488,7 +488,7 @@ impl_for_primitive!(f64 => Py<PyFloat>);
 
 // ==== FrozenSet ====
 
-impl<'a, T, Hasher> ToPython<Py<PyFrozenSet>> for &'a HashSet<T, Hasher>
+impl<T, Hasher> ToPython<Py<PyFrozenSet>> for &HashSet<T, Hasher>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -510,7 +510,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PyFrozenSet>> for &'a BTreeSet<T>
+impl<T> ToPython<Py<PyFrozenSet>> for &BTreeSet<T>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -563,7 +563,7 @@ impl_for_primitive!(usize => Py<PyLong>);
 
 // ==== Optional[T] ====
 
-impl<'a, T, P> ToPython<Option<P>> for &'a Option<T>
+impl<T, P> ToPython<Option<P>> for &Option<T>
 where
     T: ToPython<P>,
     P: ToPyObject,
@@ -587,7 +587,7 @@ where
 
 impl_for_self!(Py<PyList>);
 
-impl<'a, T, P> ToPython<Vec<P>> for &'a [T]
+impl<T, P> ToPython<Vec<P>> for &[T]
 where
     T: ToPython<P> + Clone,
     P: ToPyObject,
@@ -599,7 +599,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PyList>> for &'a [T]
+impl<T> ToPython<Py<PyList>> for &[T]
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -612,7 +612,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PyAny>> for &'a [T]
+impl<T> ToPython<Py<PyAny>> for &[T]
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -659,7 +659,7 @@ where
     }
 }
 
-impl<'a, T, P> ToPython<Vec<P>> for &'a Vec<T>
+impl<T, P> ToPython<Vec<P>> for &Vec<T>
 where
     T: ToPython<P> + Clone,
     P: ToPyObject,
@@ -678,7 +678,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PyList>> for &'a Vec<T>
+impl<T> ToPython<Py<PyList>> for &Vec<T>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -696,7 +696,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PyAny>> for &'a Vec<T>
+impl<T> ToPython<Py<PyAny>> for &Vec<T>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -709,7 +709,7 @@ where
 
 impl_for_self!(Py<PySet>);
 
-impl<'a, T, P, Hasher> ToPython<HashSet<P, Hasher>> for &'a HashSet<T, Hasher>
+impl<T, P, Hasher> ToPython<HashSet<P, Hasher>> for &HashSet<T, Hasher>
 where
     T: ToPython<P> + Clone,
     P: ToPyObject + std::hash::Hash + Eq,
@@ -733,7 +733,7 @@ where
     }
 }
 
-impl<'a, T, Hasher> ToPython<Py<PySet>> for &'a HashSet<T, Hasher>
+impl<T, Hasher> ToPython<Py<PySet>> for &HashSet<T, Hasher>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -756,7 +756,7 @@ where
     }
 }
 
-impl<'a, T, Hasher> ToPython<Py<PyAny>> for &'a HashSet<T, Hasher>
+impl<T, Hasher> ToPython<Py<PyAny>> for &HashSet<T, Hasher>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -774,7 +774,7 @@ where
     }
 }
 
-impl<'a, T, P> ToPython<BTreeSet<P>> for &'a BTreeSet<T>
+impl<T, P> ToPython<BTreeSet<P>> for &BTreeSet<T>
 where
     T: ToPython<P> + Clone,
     // Hash is required for the ToPyObject impl
@@ -797,7 +797,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PySet>> for &'a BTreeSet<T>
+impl<T> ToPython<Py<PySet>> for &BTreeSet<T>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {
@@ -820,7 +820,7 @@ where
     }
 }
 
-impl<'a, T> ToPython<Py<PyAny>> for &'a BTreeSet<T>
+impl<T> ToPython<Py<PyAny>> for &BTreeSet<T>
 where
     T: ToPython<Py<PyAny>> + Clone,
 {


### PR DESCRIPTION
Updates `time` and `thiserror`, but leaves `pyo3` as there are breaking changes that will require comparatively a lot of work.