### PR TITLE
feat: macro ergonomics improvements

### DIFF
--- a/rigetti-pyo3/src/errors.rs
+++ b/rigetti-pyo3/src/errors.rs
@@ -4,10 +4,10 @@
 /// Create a new Python exception.
 #[macro_export]
 macro_rules! create_exception {
-    ( $module:expr, $py_err: ident, $base: ty ) => {
+    ( $module:expr, $py_err:ident, $base:ty $(,)? ) => {
         $crate::create_exception!($module, $py_err, $base, "");
     };
-    ( $module:expr, $py_err: ident, $base: ty, $doc: expr ) => {
+    ( $module:expr, $py_err:ident, $base:ty, $doc:expr $(,)? ) => {
         $crate::pyo3::create_exception!($module, $py_err, $base, $doc);
     };
 }
@@ -17,10 +17,10 @@ macro_rules! create_exception {
 /// based on whether a "stubs" features is active.
 #[macro_export]
 macro_rules! create_exception {
-    ( $module:expr, $py_err: ident, $base: ty ) => {
+    ( $module:expr, $py_err:ident, $base:ty $(,)? ) => {
         $crate::create_exception!($module, $py_err, $base, "");
     };
-    ( $module:expr, $py_err: ident, $base: ty, $doc: expr ) => {
+    ( $module:expr, $py_err:ident, $base:ty, $doc:expr $(,)? ) => {
         $crate::pyo3::create_exception!($module, $py_err, $base, $doc);
 
         #[cfg(feature = "stubs")]
@@ -57,7 +57,7 @@ macro_rules! create_exception {
 /// Note that the exception class must still be added to the module.
 #[macro_export]
 macro_rules! exception {
-    ( $rust_err: ty, $module:expr, $py_err: ident, $base: ty $(, $doc: expr)? ) => {
+    ( $rust_err:ty, $module:expr, $py_err:ident, $base:ty $(, $doc:expr)? $(,)? ) => {
         $crate::create_exception!( $module, $py_err, $base $(, $doc)? );
 
         #[doc = concat!(

--- a/rigetti-pyo3/src/lib.rs
+++ b/rigetti-pyo3/src/lib.rs
@@ -142,12 +142,12 @@ use pyo3::{prelude::*, types::PyType};
 macro_rules! create_init_submodule {
     (
         $(#[$meta:meta])*
-        $(classes: [ $($class: ty),+ ],)?
-        $(complex_enums: [ $($complex_enum: ty),+ ],)?
-        $(consts: [ $($const: ident),+ ],)?
-        $(errors: [ $($error: ty),+ ],)?
-        $(funcs: [ $($func: path),+ ],)?
-        $(submodules: [ $($mod_name: literal: $init_submod: path),+ ],)?
+        $(classes: [ $($class: ty),+  $(,)? ],)?
+        $(complex_enums: [ $($complex_enum: ty),+ $(,)? ],)?
+        $(consts: [ $($const: ident),+ $(,)? ],)?
+        $(errors: [ $($error: ty),+ $(,)? ],)?
+        $(funcs: [ $($func: path),+ $(,)? ],)?
+        $(submodules: [ $($mod_name: literal: $init_submod: path),+ $(,)? ],)?
     ) => {
         $(#[$meta])*
         pub(crate) fn init_submodule<'py>(_name: &str, _py: $crate::pyo3::Python<'py>, m: &$crate::pyo3::Bound<'py, $crate::pyo3::types::PyModule>) -> $crate::pyo3::PyResult<()> {

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -124,8 +124,8 @@ where
 /// }
 ///
 /// #[pyo3(name="say_hello")]
-/// pub fn py_say_hello(name: String) -> PyResult<String> {
-///     py_sync!(say_hello(name))
+/// pub fn py_say_hello(py: Python<'_>, name: String) -> PyResult<String> {
+///     py_sync!(py, say_hello(name))
 /// }
 /// ```
 ///
@@ -135,14 +135,16 @@ where
 /// ```
 #[macro_export]
 macro_rules! py_sync {
-    ($py: ident, $body: expr) => {{
+    ($py:ident, $body:expr $(,)?) => {{
         $py.detach(|| {
             let runtime = $crate::pyo3_async_runtimes::tokio::get_runtime();
             let handle = runtime.spawn($body);
 
             runtime.block_on(async {
                 $crate::tokio::select! {
-                    result = handle => result.map_err(|err| $crate::pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?,
+                    result = handle => result.map_err(|err|
+                        $crate::pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
+                    )?,
                     signal_err = async {
                         // A 100ms loop delay is a bit arbitrary, but seems to
                         // balance CPU usage and SIGINT responsiveness well enough.
@@ -165,7 +167,7 @@ macro_rules! py_sync {
 /// `pyo3_async_runtimes::tokio::future_into_py`
 #[macro_export]
 macro_rules! py_async {
-    ($py: ident, $body: expr) => {
+    ($py:ident, $body:expr $(,)?) => {
         $crate::pyo3_async_runtimes::tokio::future_into_py($py, $body)
     };
 }

--- a/rigetti-pyo3/src/traits.rs
+++ b/rigetti-pyo3/src/traits.rs
@@ -14,35 +14,40 @@
 
 //! Macros for implementing "dunder" methods based on traits.
 
-#[cfg(not(feature = "stubs"))]
-/// Implement `__repr__` for a type that implement [`Debug`](std::fmt::Debug).
+/// Implement `__repr__` for a type that implements [`Debug`](std::fmt::Debug).
 #[macro_export]
 macro_rules! impl_repr {
-    ($name: ident) => {
-        #[$crate::pyo3::pymethods]
-        impl $name {
-            /// Implements `__repr__` for Python in terms of the Rust
-            /// [`Debug`](std::fmt::Debug) implementation.
-            pub fn __repr__(&self) -> String {
-                format!("{self:?}")
+    ($($name:ident),* $(,)?) => {
+        $(
+            $crate::guard_with_cfg_stubs! {
+                #[$crate::pyo3::pymethods]
+                impl $name {
+                    /// Implements `__repr__` for Python in terms of the Rust
+                    /// [`Debug`](std::fmt::Debug) implementation.
+                    pub fn __repr__(&self) -> String {
+                        format!("{self:?}")
+                    }
+                }
             }
-        }
+        )*
     };
 }
 
-#[cfg(feature = "stubs")]
-/// Implement `__repr__` for a type that implement [`Debug`](std::fmt::Debug).
+#[cfg(not(feature = "stubs"))]
+#[doc(hidden)]
 #[macro_export]
-macro_rules! impl_repr {
-    ($name: ident) => {
+macro_rules! guard_with_cfg_stubs {
+    ($($body:tt)*) => {
+        $($body)*
+    }
+}
+
+#[cfg(feature = "stubs")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! guard_with_cfg_stubs {
+    ($($body:tt)*) => {
         #[cfg_attr(feature = "stubs", $crate::pyo3_stub_gen::derive::gen_stub_pymethods)]
-        #[$crate::pyo3::pymethods]
-        impl $name {
-            /// Implements `__repr__` for Python in terms of the Rust
-            /// [`Debug`](std::fmt::Debug) implementation.
-            pub fn __repr__(&self) -> String {
-                format!("{self:?}")
-            }
-        }
-    };
+        $($body)*
+    }
 }

--- a/rigetti-pyo3/src/traits.rs
+++ b/rigetti-pyo3/src/traits.rs
@@ -19,7 +19,7 @@
 macro_rules! impl_repr {
     ($($name:ident),* $(,)?) => {
         $(
-            $crate::guard_with_cfg_stubs! {
+            $crate::maybe_add_cfg_stubs_gen_stub_pymethods! {
                 #[$crate::pyo3::pymethods]
                 impl $name {
                     /// Implements `__repr__` for Python in terms of the Rust
@@ -36,7 +36,7 @@ macro_rules! impl_repr {
 #[cfg(not(feature = "stubs"))]
 #[doc(hidden)]
 #[macro_export]
-macro_rules! guard_with_cfg_stubs {
+macro_rules! maybe_add_cfg_stubs_gen_stub_pymethods {
     ($($body:tt)*) => {
         $($body)*
     }
@@ -45,7 +45,7 @@ macro_rules! guard_with_cfg_stubs {
 #[cfg(feature = "stubs")]
 #[doc(hidden)]
 #[macro_export]
-macro_rules! guard_with_cfg_stubs {
+macro_rules! maybe_add_cfg_stubs_gen_stub_pymethods {
     ($($body:tt)*) => {
         #[cfg_attr(feature = "stubs", $crate::pyo3_stub_gen::derive::gen_stub_pymethods)]
         $($body)*


### PR DESCRIPTION
Adds support for trailing commas to macros and lets `impl_repr!` take multiple type names at once.