### PR TITLE
fix(rigetti-pyo3): use existing Python event loop from synchronous functions, when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rigetti-pyo3"
-version = "0.5.1"
+version = "0.5.2-rc.0"
 dependencies = [
  "indexmap",
  "itertools 0.14.0",

--- a/rigetti-pyo3/CHANGELOG.md
+++ b/rigetti-pyo3/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.2-rc.0 (2026-04-16)
+
+### Fixes
+
+- in synchronous functions calling async code, use existing Python event loop if possible
+
 ## 0.5.1 (2026-03-25)
 
 ### Features

--- a/rigetti-pyo3/Cargo.toml
+++ b/rigetti-pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rigetti-pyo3"
-version = "0.5.1"
+version = "0.5.2-rc.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rigetti/rigetti-pyo3"

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -148,8 +148,12 @@ macro_rules! py_sync {
     }};
 }
 
+/// The variable name to extract after executing `PY_CODE_WORKER_EVENT_LOOP` to get the worker event loop.
 // This must match the name of the value defined in `PY_CODE_WORKER_EVENT_LOOP` below.
 const PY_VARNAME_LOOP: &str = "loop";
+/// The Python code snippet to set up a long-running background thread to run Rust futures from a
+/// synchronous Python context.
+/// This should only be run once per process.
 const PY_CODE_WORKER_EVENT_LOOP: &str = r#"
 import asyncio
 import threading
@@ -173,8 +177,12 @@ _thread.start()
 loop = loop_fut.result(timeout=1)
 "#;
 
+/// The function name to extract after executing `PY_CODE_RUN_ON_LOOP` to get the helper function
+/// for running a coroutine on the worker event loop.
 // This must match the name of the function defined in `PY_CODE_RUN_ON_LOOP` below.
 const PY_FUNCNAME_RUN_ON_LOOP: &str = "get_result";
+/// The Python code snippet to run a coroutine on the worker event loop and block until it returns
+/// a result.
 const PY_CODE_RUN_ON_LOOP: &str = r"
 import asyncio
 

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -163,8 +163,8 @@ loop_fut = concurrent.futures.Future[asyncio.AbstractEventLoop]()
 
 def _run_loop() -> None:
     loop = asyncio.new_event_loop()
-    loop_fut.set_result(loop)
     asyncio.set_event_loop(loop)
+    loop_fut.set_result(loop)
     loop.run_forever()
 
 _thread = threading.Thread(

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -7,7 +7,7 @@ use pyo3_stub_gen::{PyStubType, TypeInfo};
 use std::{
     ffi::CString,
     future::Future,
-    sync::{mpsc, Arc, Mutex},
+    sync::{Arc, Mutex},
 };
 use std::{marker::PhantomData, sync::LazyLock};
 
@@ -144,48 +144,51 @@ where
 #[macro_export]
 macro_rules! py_sync {
     ($py:ident, $body:expr $(,)?) => {{
-        $crate::sync::invoke_async_from_py_sync($body)
+        $crate::sync::invoke_async_from_py_sync($py, $body)
     }};
 }
 
 static PY_WORKER_EVENT_LOOP: LazyLock<Py<PyAny>> = LazyLock::new(|| {
-    // Spawn a Python thread; start an event loop there.
-    // Return a handle to the Python event loop.
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        Python::attach(|py| {
-            let code = CString::new(
-                r#"
+    // Create a worker event loop and start it on a Python-created daemon thread.
+    Python::attach(|py| {
+        let code = CString::new(
+            r#"
 import asyncio
+import threading
+import time
 
-# Create and set up the event loop
 loop = asyncio.new_event_loop()
-asyncio.set_event_loop(loop)
 
-# Run the loop indefinitely (this will block the thread from completing until cancelled)
-loop.run_until_complete(asyncio.sleep(float('inf')))
+def _run_loop() -> None:
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+thread = threading.Thread(
+    target=_run_loop,
+    name="rigetti-pyo3-worker-loop",
+    daemon=True,
+)
+thread.start()
+
+for _ in range(1000):
+    if loop.is_running():
+        break
+    time.sleep(0.001)
+else:
+    raise RuntimeError("worker event loop failed to start")
 "#,
-            )
-            .unwrap();
-            let module_name = CString::new("py_worker_event_loop").unwrap();
+        )
+        .unwrap();
+        let module_name = CString::new("py_worker_event_loop").unwrap();
 
-            let module = PyModule::from_code(py, &code, &module_name, &module_name)
-                .expect("failed to create worker event loop module");
+        let module = PyModule::from_code(py, &code, &module_name, &module_name)
+            .expect("failed to create worker event loop module");
 
-            // Get the loop variable from the module
-            let loop_obj = module
-                .getattr("loop")
-                .expect("failed to get loop from module");
-
-            // Send the loop to the channel
-            let py_loop = loop_obj.into();
-            let _ = tx.send(py_loop);
-        })
-    });
-
-    // Wait for the worker thread to create and send the event loop
-    rx.recv()
-        .expect("failed to receive event loop from worker thread")
+        module
+            .getattr("loop")
+            .expect("failed to get loop from module")
+            .into()
+    })
 });
 
 /// Spawn and block on a future using the pyo3 tokio runtime.
@@ -194,7 +197,7 @@ loop.run_until_complete(asyncio.sleep(float('inf')))
 /// This function is only necessary as a workaround for https://github.com/PyO3/pyo3-async-runtimes/issues/81.
 ///
 #[cfg(feature = "async-tokio")]
-pub async fn invoke_async_from_py_sync<F, T>(py: ::pyo3::Python<'_>, body: F) -> PyResult<T>
+pub fn invoke_async_from_py_sync<F, T>(py: ::pyo3::Python<'_>, body: F) -> PyResult<T>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
     T: Send + Sync + 'static,
@@ -215,10 +218,24 @@ where
         },
     )?;
 
+    // `future_into_py_with_locals` returns an awaitable; wrap it into a coroutine object
+    // because `run_coroutine_threadsafe` requires a coroutine specifically.
+    let helper_code = CString::new(
+        r#"
+async def _to_coroutine(awaitable):
+    return await awaitable
+"#,
+    )
+    .unwrap();
+    let helper_module_name = CString::new("py_worker_event_loop_helper").unwrap();
+    let helper_module =
+        PyModule::from_code(py, &helper_code, &helper_module_name, &helper_module_name)?;
+    let wrapped_coro = helper_module.getattr("_to_coroutine")?.call1((&coro,))?;
+
     // Call `asyncio.run_coroutine_threadsafe` using `PY_WORKER_EVENT_LOOP`
     let run_coro_threadsafe = py.import("asyncio")?.getattr("run_coroutine_threadsafe")?;
     let concurrent_future =
-        run_coro_threadsafe.call((&coro, PY_WORKER_EVENT_LOOP.bind(py)), None)?;
+        run_coro_threadsafe.call((wrapped_coro, PY_WORKER_EVENT_LOOP.bind(py)), None)?;
 
     // Block waiting for the result with a timeout
     let timeout_secs = 30.0;
@@ -305,7 +322,7 @@ macro_rules! py_function_sync_async {
         #[pyo3(name = $name "")]
         $pub fn [< py_ $name >](py: $crate::pyo3::Python<'_> $(, $(#[$arg_meta])*$arg: $kind)*) $(-> PyResult<$ret>)? {
             let res = $crate::sync::add_context_if_otel([< $name _impl >]($($arg),*));
-            $crate::py_sync!(py, res)
+            $crate::sync::invoke_async_from_py_sync(py, res)
         }
         }
 

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -148,46 +148,58 @@ macro_rules! py_sync {
     }};
 }
 
+// This must match the name of the value defined in `PY_CODE_WORKER_EVENT_LOOP` below.
+const PY_VARNAME_LOOP: &str = "loop";
+const PY_CODE_WORKER_EVENT_LOOP: &str = r#"
+import asyncio
+import threading
+import concurrent.futures
+
+loop_fut = concurrent.futures.Future[asyncio.AbstractEventLoop]()
+
+def _run_loop() -> None:
+    loop = asyncio.new_event_loop()
+    loop_fut.set_result(loop)
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+_thread = threading.Thread(
+    target=_run_loop,
+    name="rigetti-pyo3-worker-loop",
+    # Daemon threads do not prevent the Python process from exiting.
+    daemon=True,
+)
+_thread.start()
+loop = loop_fut.result(timeout=1)
+"#;
+
+// This must match the name of the function defined in `PY_CODE_RUN_ON_LOOP` below.
+const PY_FUNCNAME_RUN_ON_LOOP: &str = "get_result";
+const PY_CODE_RUN_ON_LOOP: &str = r"
+import asyncio
+
+def get_result(loop, awaitable):
+    async def _run_coroutine():
+        return await awaitable
+    
+    return asyncio.run_coroutine_threadsafe(
+        _run_coroutine(),
+        loop,
+    ).result()
+";
+
 /// Worker event loop used for running asynchronous tasks from synchronous Python code.
 static PY_WORKER_EVENT_LOOP: LazyLock<Py<PyAny>> = LazyLock::new(|| {
     // Create a worker event loop and start it on a Python-created daemon thread.
     Python::attach(|py| {
-        let code = CString::new(
-            r#"
-import asyncio
-import threading
-import time
-
-loop = asyncio.new_event_loop()
-
-def _run_loop() -> None:
-    asyncio.set_event_loop(loop)
-    loop.run_forever()
-
-thread = threading.Thread(
-    target=_run_loop,
-    name="rigetti-pyo3-worker-loop",
-    daemon=True,
-)
-thread.start()
-
-for _ in range(1000):
-    if loop.is_running():
-        break
-    time.sleep(0.001)
-else:
-    raise RuntimeError("rigetti-pyo3 worker event loop failed to start")
-"#,
-        )
-        .unwrap();
+        let code = CString::new(PY_CODE_WORKER_EVENT_LOOP).unwrap();
         let module_name = CString::new("py_worker_event_loop").unwrap();
-
         let module = PyModule::from_code(py, &code, &module_name, &module_name)
             .expect("failed to create worker event loop module");
 
         module
-            .getattr("loop")
-            .expect("failed to get loop from module")
+            .getattr(PY_VARNAME_LOOP)
+            .expect("failed to get Python event loop variable from module")
             .into()
     })
 });
@@ -230,28 +242,13 @@ where
 
     // `future_into_py_with_locals` returns an awaitable; wrap it into a coroutine object
     // because `run_coroutine_threadsafe` requires a coroutine specifically.
-    let helper_code = CString::new(
-        r"
-import asyncio
+    let code = CString::new(PY_CODE_RUN_ON_LOOP).unwrap();
 
-def get_result(loop, awaitable):
-    async def _run_coroutine():
-        return await awaitable
-    
-    return asyncio.run_coroutine_threadsafe(
-        _run_coroutine(),
-        loop,
-    ).result(timeout=30)
-",
-    )
-    .unwrap();
+    let module_name = CString::new("py_worker_event_loop_helper").unwrap();
+    let module = PyModule::from_code(py, &code, &module_name, &module_name)?;
 
-    let helper_module_name = CString::new("py_worker_event_loop_helper").unwrap();
-    let helper_module =
-        PyModule::from_code(py, &helper_code, &helper_module_name, &helper_module_name)?;
-
-    let _ = helper_module
-        .getattr("get_result")?
+    let _ = module
+        .getattr(PY_FUNCNAME_RUN_ON_LOOP)?
         .call((PY_WORKER_EVENT_LOOP.bind(py), &coro), None)?;
 
     let result = result_rx

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -116,6 +116,10 @@ where
 /// Spawn and block on a future using the pyo3 tokio runtime.
 /// Useful for returning a synchronous `PyResult`.
 ///
+/// This function is only necessary as a workaround for https://github.com/PyO3/pyo3-async-runtimes/issues/81.
+///
+/// This is only a macro for backwards compatibility with older versions of the crate;
+/// we can replace it with a function in a breaking-change release.
 ///
 /// When used like the following:
 /// ```rs
@@ -136,29 +140,12 @@ where
 #[macro_export]
 macro_rules! py_sync {
     ($py:ident, $body:expr $(,)?) => {{
-        $py.detach(|| {
-            let runtime = $crate::pyo3_async_runtimes::tokio::get_runtime();
-            let handle = runtime.spawn($body);
-
-            runtime.block_on(async {
-                $crate::tokio::select! {
-                    result = handle => result.map_err(|err|
-                        $crate::pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
-                    )?,
-                    signal_err = async {
-                        // A 100ms loop delay is a bit arbitrary, but seems to
-                        // balance CPU usage and SIGINT responsiveness well enough.
-                        let delay = ::std::time::Duration::from_millis(100);
-                        loop {
-                            $crate::pyo3::Python::attach(|py| {
-                                py.check_signals()
-                            })?;
-                            $crate::tokio::time::sleep(delay).await;
-                        }
-                    } => signal_err,
-                }
-            })
-        })
+        if let Ok(event_loop) = $crate::pyo3_async_runtimes::tokio::get_current_loop($py)
+        {
+            $crate::pyo3_async_runtimes::tokio::run_until_complete(event_loop, $body)
+        } else {
+            $crate::pyo3_async_runtimes::tokio::run($py, $body)
+        }
     }};
 }
 
@@ -193,8 +180,7 @@ macro_rules! py_async {
 ///
 /// This macro cannot be used when lifetime specifiers are
 /// required, or the pyfunction bodies need additional
-/// parameter handling besides simply calling out to
-/// the underlying `py_async` or `py_sync` macros.
+/// parameter handling.
 ///
 /// ```rs
 /// // ... becomes python package "things"
@@ -240,7 +226,7 @@ macro_rules! py_function_sync_async {
         #[pyo3(name = $name "")]
         $pub fn [< py_ $name >](py: $crate::pyo3::Python<'_> $(, $(#[$arg_meta])*$arg: $kind)*) $(-> PyResult<$ret>)? {
             let res = $crate::sync::add_context_if_otel([< $name _impl >]($($arg),*));
-            $crate::pyo3_async_runtimes::tokio::run(py, res)
+            $crate::py_sync!(py, res)
         }
         }
 

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -176,7 +176,7 @@ for _ in range(1000):
         break
     time.sleep(0.001)
 else:
-    raise RuntimeError("worker event loop failed to start")
+    raise RuntimeError("rigetti-pyo3 worker event loop failed to start")
 "#,
         )
         .unwrap();
@@ -232,26 +232,33 @@ where
     // because `run_coroutine_threadsafe` requires a coroutine specifically.
     let helper_code = CString::new(
         r"
-async def _to_coroutine(awaitable):
-    return await awaitable
+import asyncio
+
+def get_result(loop, awaitable):
+    async def _run_coroutine():
+        return await awaitable
+    
+    return asyncio.run_coroutine_threadsafe(
+        _run_coroutine(),
+        loop,
+    ).result(timeout=30)
 ",
     )
     .unwrap();
+
     let helper_module_name = CString::new("py_worker_event_loop_helper").unwrap();
     let helper_module =
         PyModule::from_code(py, &helper_code, &helper_module_name, &helper_module_name)?;
-    let wrapped_coro = helper_module.getattr("_to_coroutine")?.call1((&coro,))?;
 
-    // Call `asyncio.run_coroutine_threadsafe` using `PY_WORKER_EVENT_LOOP`
-    let run_coro_threadsafe = py.import("asyncio")?.getattr("run_coroutine_threadsafe")?;
-    let concurrent_future =
-        run_coro_threadsafe.call((wrapped_coro, PY_WORKER_EVENT_LOOP.bind(py)), None)?;
+    let _ = helper_module
+        .getattr("get_result")?
+        .call((PY_WORKER_EVENT_LOOP.bind(py), &coro), None)?;
 
-    // Block waiting for the result with a timeout
-    let timeout_secs = 30.0;
-    let _ = concurrent_future.call_method1("result", (timeout_secs,))?;
-
-    let result = result_rx.lock().unwrap().take().unwrap();
+    let result = result_rx
+        .lock()
+        .unwrap()
+        .take()
+        .expect("future must always produce either a result or an error");
     Ok(result)
 }
 

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -148,6 +148,7 @@ macro_rules! py_sync {
     }};
 }
 
+/// Worker event loop used for running asynchronous tasks from synchronous Python code.
 static PY_WORKER_EVENT_LOOP: LazyLock<Py<PyAny>> = LazyLock::new(|| {
     // Create a worker event loop and start it on a Python-created daemon thread.
     Python::attach(|py| {
@@ -194,8 +195,17 @@ else:
 /// Spawn and block on a future using the pyo3 tokio runtime.
 /// Useful for returning a synchronous `PyResult`.
 ///
-/// This function is only necessary as a workaround for https://github.com/PyO3/pyo3-async-runtimes/issues/81.
+/// This function is only necessary as a workaround for <https://github.com/PyO3/pyo3-async-runtimes/issues/81>.
 ///
+///
+/// # Errors
+///
+/// Returns the result of the asynchronous operation, or an error if the operation fails, or if a
+/// PyO3 failure prevents invoking the asynchronous operation.
+///
+/// # Panics
+///
+/// Panics if a lock has been poisoned or if certain string-literals are invalid C strings.
 #[cfg(feature = "async-tokio")]
 pub fn invoke_async_from_py_sync<F, T>(py: ::pyo3::Python<'_>, body: F) -> PyResult<T>
 where
@@ -221,10 +231,10 @@ where
     // `future_into_py_with_locals` returns an awaitable; wrap it into a coroutine object
     // because `run_coroutine_threadsafe` requires a coroutine specifically.
     let helper_code = CString::new(
-        r#"
+        r"
 async def _to_coroutine(awaitable):
     return await awaitable
-"#,
+",
     )
     .unwrap();
     let helper_module_name = CString::new("py_worker_event_loop_helper").unwrap();

--- a/rigetti-pyo3/src/sync.rs
+++ b/rigetti-pyo3/src/sync.rs
@@ -3,7 +3,13 @@
 use pyo3::prelude::*;
 #[cfg(feature = "stubs")]
 use pyo3_stub_gen::{PyStubType, TypeInfo};
-use std::marker::PhantomData;
+#[cfg(feature = "async-tokio")]
+use std::{
+    ffi::CString,
+    future::Future,
+    sync::{mpsc, Arc, Mutex},
+};
+use std::{marker::PhantomData, sync::LazyLock};
 
 /// The result of an asynchronous Python function.
 ///
@@ -116,8 +122,6 @@ where
 /// Spawn and block on a future using the pyo3 tokio runtime.
 /// Useful for returning a synchronous `PyResult`.
 ///
-/// This function is only necessary as a workaround for https://github.com/PyO3/pyo3-async-runtimes/issues/81.
-///
 /// This is only a macro for backwards compatibility with older versions of the crate;
 /// we can replace it with a function in a breaking-change release.
 ///
@@ -140,13 +144,88 @@ where
 #[macro_export]
 macro_rules! py_sync {
     ($py:ident, $body:expr $(,)?) => {{
-        if let Ok(event_loop) = $crate::pyo3_async_runtimes::tokio::get_current_loop($py)
-        {
-            $crate::pyo3_async_runtimes::tokio::run_until_complete(event_loop, $body)
-        } else {
-            $crate::pyo3_async_runtimes::tokio::run($py, $body)
-        }
+        $crate::sync::invoke_async_from_py_sync($body)
     }};
+}
+
+static PY_WORKER_EVENT_LOOP: LazyLock<Py<PyAny>> = LazyLock::new(|| {
+    // Spawn a Python thread; start an event loop there.
+    // Return a handle to the Python event loop.
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        Python::attach(|py| {
+            let code = CString::new(
+                r#"
+import asyncio
+
+# Create and set up the event loop
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+
+# Run the loop indefinitely (this will block the thread from completing until cancelled)
+loop.run_until_complete(asyncio.sleep(float('inf')))
+"#,
+            )
+            .unwrap();
+            let module_name = CString::new("py_worker_event_loop").unwrap();
+
+            let module = PyModule::from_code(py, &code, &module_name, &module_name)
+                .expect("failed to create worker event loop module");
+
+            // Get the loop variable from the module
+            let loop_obj = module
+                .getattr("loop")
+                .expect("failed to get loop from module");
+
+            // Send the loop to the channel
+            let py_loop = loop_obj.into();
+            let _ = tx.send(py_loop);
+        })
+    });
+
+    // Wait for the worker thread to create and send the event loop
+    rx.recv()
+        .expect("failed to receive event loop from worker thread")
+});
+
+/// Spawn and block on a future using the pyo3 tokio runtime.
+/// Useful for returning a synchronous `PyResult`.
+///
+/// This function is only necessary as a workaround for https://github.com/PyO3/pyo3-async-runtimes/issues/81.
+///
+#[cfg(feature = "async-tokio")]
+pub async fn invoke_async_from_py_sync<F, T>(py: ::pyo3::Python<'_>, body: F) -> PyResult<T>
+where
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: Send + Sync + 'static,
+{
+    // Copied from `pyo3_async_runtimes`:
+    let result_tx = Arc::new(Mutex::new(None));
+    let result_rx = Arc::clone(&result_tx);
+    let coro = ::pyo3_async_runtimes::tokio::future_into_py_with_locals(
+        py,
+        ::pyo3_async_runtimes::TaskLocals::new(PY_WORKER_EVENT_LOOP.bind(py).to_owned())
+            .copy_context(py)?,
+        async move {
+            let val = body.await?;
+            if let Ok(mut result) = result_tx.lock() {
+                *result = Some(val);
+            }
+            Ok(())
+        },
+    )?;
+
+    // Call `asyncio.run_coroutine_threadsafe` using `PY_WORKER_EVENT_LOOP`
+    let run_coro_threadsafe = py.import("asyncio")?.getattr("run_coroutine_threadsafe")?;
+    let concurrent_future =
+        run_coro_threadsafe.call((&coro, PY_WORKER_EVENT_LOOP.bind(py)), None)?;
+
+    // Block waiting for the result with a timeout
+    let timeout_secs = 30.0;
+    let _ = concurrent_future.call_method1("result", (timeout_secs,))?;
+
+    let result = result_rx.lock().unwrap().take().unwrap();
+    Ok(result)
 }
 
 #[cfg(feature = "async-tokio")]


### PR DESCRIPTION
Proposed fix for #69.